### PR TITLE
Extend source and destination columns

### DIFF
--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -239,7 +239,7 @@ pub fn draw_ui(
 /// Get header of packet capture UI
 fn get_packets_ui_header() -> String {
     format!(
-        "{:<20}    {:<20}    {:<10}    {:<6}    {:<20}",
+        "{:<40}    {:<40}    {:<10}    {:<6}    {:<20}",
         "Source", "Destination", "Protocol", "Length", "Info"
     )
 }
@@ -266,7 +266,7 @@ fn get_packet_info(packet: &PacketInfo) -> String {
             let tcp = TcpPacket::new(raw_packet);
             if let Some(tcp) = tcp {
                 format!(
-                    "{:<20}    {:<20}    {:<10}    {:<6}    {:<6}->{:<6}",
+                    "{:<40}    {:<40}    {:<10}    {:<6}    {:<6}->{:<6}",
                     source_ip,
                     dest_ip,
                     "TCP",
@@ -297,7 +297,7 @@ fn get_packet_info(packet: &PacketInfo) -> String {
             let udp = UdpPacket::new(raw_packet);
             if let Some(udp) = udp {
                 format!(
-                    "{:<20}    {:<20}    {:<10}    {:<6}    {:<6}->{:<6}",
+                    "{:<40}    {:<40}    {:<10}    {:<6}    {:<6}->{:<6}",
                     source_ip,
                     dest_ip,
                     "UDP",
@@ -317,7 +317,7 @@ fn get_packet_info(packet: &PacketInfo) -> String {
 
             if let Some(arp) = arp {
                 format!(
-                    "{:<20}    {:<20}    {:<10}    {:<6}    {:?}",
+                    "{:<40}    {:<40}    {:<10}    {:<6}    {:?}",
                     arp.get_sender_hw_addr(),
                     arp.get_target_hw_addr(),
                     "ARP",
@@ -349,7 +349,7 @@ fn get_packet_info(packet: &PacketInfo) -> String {
             // TODO: Improve print information based on ICMP Type
             if let Some(icmp) = icmp {
                 format!(
-                    "{:<20}    {:<20}    {:<10}    {:<6}    {:?}",
+                    "{:<40}    {:<40}    {:<10}    {:<6}    {:?}",
                     source_ip,
                     dest_ip,
                     "ICMP",


### PR DESCRIPTION
Extend source and destination columns to fit IPv6 addresses. Closes #9 

IPv6 addresses are going to be around a max of 40 chars (8 groups x 4 hex + 7 colons). Tested locally and looks good.

![image](https://user-images.githubusercontent.com/6572184/90847113-99f95600-e31e-11ea-8850-353143057c45.png)

