### PR TITLE
Easier to view port mapping

### DIFF
--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -266,7 +266,7 @@ fn get_packet_info(packet: &PacketInfo) -> String {
             let tcp = TcpPacket::new(raw_packet);
             if let Some(tcp) = tcp {
                 format!(
-                    "{:<40}    {:<40}    {:<10}    {:<6}    {:<6}->{:<6}",
+                    "{:<40}    {:<40}    {:<10}    {:<6}    {:<6} -> {:<6}",
                     source_ip,
                     dest_ip,
                     "TCP",
@@ -297,7 +297,7 @@ fn get_packet_info(packet: &PacketInfo) -> String {
             let udp = UdpPacket::new(raw_packet);
             if let Some(udp) = udp {
                 format!(
-                    "{:<40}    {:<40}    {:<10}    {:<6}    {:<6}->{:<6}",
+                    "{:<40}    {:<40}    {:<10}    {:<6}    {:<6} -> {:<6}",
                     source_ip,
                     dest_ip,
                     "UDP",


### PR DESCRIPTION
Small fix to make it easier to view the port mapping, this is how it is done in wireshark

![image](https://user-images.githubusercontent.com/6572184/90945455-de95f780-e3d9-11ea-9e57-f666c48f8d08.png)

![image](https://user-images.githubusercontent.com/6572184/90945476-ef466d80-e3d9-11ea-8d70-d0230e409527.png)

