### PR TITLE
Ctrl-c quits the program (#20)

### DIFF
--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -147,7 +147,7 @@ pub fn draw_ui(
         // Capture events from the keyboard
         match events.next()? {
             Event::Input(input) => match input {
-                Key::Char('q') => {
+                Key::Char('q') | Key::Ctrl('c') => {
                     terminal.clear()?;
                     running.store(false, Ordering::SeqCst);
                 }


### PR DESCRIPTION
I had some issues creating a handler thread and getting it to work, so opting for the bandaid solution here. 

Tested locally and a ctrl+c quits the program successfully.

Closes #20 