### PR TITLE
Add signal handler for ctrl-c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,10 +48,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cc"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -66,6 +78,16 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
+dependencies = [
+ "nix",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -110,9 +132,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.73"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "log"
@@ -129,7 +151,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -137,6 +159,18 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+dependencies = [
+ "bitflags 1.2.1",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+]
 
 [[package]]
 name = "numtoa"
@@ -271,6 +305,7 @@ name = "rshark"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "ctrlc",
  "pnet",
  "termion",
  "tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 clap = "2.33.3"
 tui = "0.10"
 termion = "1.5"
+ctrlc = { version = "3.0", features = ["termination"] }
 
 [dependencies.pnet]
 version = "0.26.0"

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -148,7 +148,7 @@ pub fn draw_ui(
         // Capture events from the keyboard
         match events.next()? {
             Event::Input(input) => match input {
-                Key::Char('q') | Key::Ctrl('c') => {
+                Key::Char('q') => {
                     terminal.clear()?;
                     running.store(false, Ordering::SeqCst);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,16 +51,17 @@ fn main() {
     let running = Arc::new(AtomicBool::new(true));
     // Maintains packets, num of captured packets and num of dropped packets
     let net_info = Arc::new(RwLock::new(NetworkInfo::new()));
-    
+
     let network_net_info = Arc::clone(&net_info);
     let ui_net_info = Arc::clone(&net_info);
-    
+
     let network_running = Arc::clone(&running);
     let display_running = Arc::clone(&running);
-    
-    ctrlc::set_handler( move || {
+
+    ctrlc::set_handler(move || {
         running.store(false, Ordering::SeqCst);
-    }).expect("Error");
+    })
+    .expect("Error");
 
     let network_sniffer_thread = thread::spawn(|| {
         start_packet_sniffer(interface, network_net_info, network_running);


### PR DESCRIPTION
Added a signal handler for control-c (unix - `SIGINT`). Set the handler in the `main.rs` file as the set_handler should be only called once. The only way to ensure that would be to keep it in `main.rs`. Additionally, was causing some borrow errors when handler was set in `ui.rs`.

Closes #25
